### PR TITLE
Harmonize getAnswerGiven with other content types

### DIFF
--- a/scripts/h5p-true-false-answer-group.js
+++ b/scripts/h5p-true-false-answer-group.js
@@ -50,7 +50,7 @@ H5P.TrueFalse.AnswerGroup = (function ($, EventDispatcher) {
     falseAnswer.on('invert', handleInvert(true, trueAnswer));
 
     // Handle tabbing
-    var handleTabable = function(other, tabable) {
+    var handleTabable = function (other, tabable) {
       return function () {
         // If one of them are checked, that one should get tabfocus
         if (!tabable || !self.hasAnswered() || other.isChecked()) {

--- a/scripts/h5p-true-false-answer-group.js
+++ b/scripts/h5p-true-false-answer-group.js
@@ -101,6 +101,15 @@ H5P.TrueFalse.AnswerGroup = (function ($, EventDispatcher) {
     };
 
     /**
+     * Return current answer
+     * @method setAnswer
+     * @param {Boolean|null} answerToSet null if no explicit answer given.
+     */
+    self.setAnswer = function (answerToSet) {
+      answer = answerToSet;
+    };
+
+    /**
      * Check if user has answered question yet
      * @method hasAnswered
      * @return {Boolean}
@@ -144,7 +153,7 @@ H5P.TrueFalse.AnswerGroup = (function ($, EventDispatcher) {
      * @method reveal
      */
     self.reveal = function () {
-      if (self.hasAnswered()) {
+      if (typeof self.hasAnswered() === 'boolean') {
         if (self.isCorrect()) {
           correctAnswer.markCorrect();
         }

--- a/scripts/h5p-true-false-answer.js
+++ b/scripts/h5p-true-false-answer.js
@@ -19,7 +19,7 @@ H5P.TrueFalse.Answer = (function ($, EventDispatcher) {
    * @param {String} correctMessage Message read by readspeaker when correct alternative is chosen
    * @param {String} wrongMessage Message read by readspeaker when wrong alternative is chosen
    */
-  function Answer (text, correctMessage, wrongMessage) {
+  function Answer(text, correctMessage, wrongMessage) {
     var self = this;
 
     EventDispatcher.call(self);

--- a/scripts/h5p-true-false.js
+++ b/scripts/h5p-true-false.js
@@ -114,11 +114,11 @@ H5P.TrueFalse = (function ($, Question) {
 
       // select find container to attach dialogs to
       var $container;
-      if($containerParents.length !== 0) {
+      if ($containerParents.length !== 0) {
         // use parent highest up if any
         $container = $containerParents.last();
       }
-      else if($content.length !== 0){
+      else if ($content.length !== 0) {
         $container = $content;
       }
       else  {
@@ -185,7 +185,7 @@ H5P.TrueFalse = (function ($, Question) {
      * @param {XAPIEvent} xAPIEvent
      * @private
      */
-    var addQuestionToXAPI = function(xAPIEvent) {
+    var addQuestionToXAPI = function (xAPIEvent) {
       var definition = xAPIEvent.getVerifiedStatementValue(['object', 'definition']);
       definition.description = {
         // Remove tags, must wrap in div tag because jQuery 1.9 will crash if the string isn't wrapped in a tag.
@@ -226,7 +226,7 @@ H5P.TrueFalse = (function ($, Question) {
      * @param {H5P.XAPIEvent} xAPIEvent
      *  The xAPI event we will add a response to
      */
-    var addResponseToXAPI = function(xAPIEvent) {
+    var addResponseToXAPI = function (xAPIEvent) {
       var isCorrect = answerGroup.isCorrect();
       xAPIEvent.setScoredResult(isCorrect ? MAX_SCORE : 0, MAX_SCORE, self, true, isCorrect);
       xAPIEvent.data.statement.result.response = (isCorrect ? getCorrectAnswer() : getWrongAnswer());
@@ -273,6 +273,7 @@ H5P.TrueFalse = (function ($, Question) {
       var score = self.getScore();
       var scoreText;
 
+      //
       answerGroup.setAnswer(null);
 
       toggleButtonState(score === MAX_SCORE ? State.FINISHED_CORRECT : State.FINISHED_WRONG);
@@ -424,7 +425,7 @@ H5P.TrueFalse = (function ($, Question) {
      *
      * @see contract at {@link https://h5p.org/documentation/developers/contracts#guides-header-6}
      */
-    self.getXAPIData = function(){
+    self.getXAPIData = function () {
       var xAPIEvent = this.createXAPIEventTemplate('answered');
       this.addQuestionToXAPI(xAPIEvent);
       this.addResponseToXAPI(xAPIEvent);
@@ -436,7 +437,7 @@ H5P.TrueFalse = (function ($, Question) {
     /**
      * Add the question itself to the definition part of an xAPIEvent
      */
-    self.addQuestionToXAPI = function(xAPIEvent) {
+    self.addQuestionToXAPI = function (xAPIEvent) {
       var definition = xAPIEvent.getVerifiedStatementValue(['object', 'definition']);
       $.extend(definition, this.getxAPIDefinition());
     };
@@ -470,12 +471,12 @@ H5P.TrueFalse = (function ($, Question) {
 
       xAPIEvent.setScoredResult(rawUserScore, MAX_SCORE, self, true, isCorrect);
 
-      if(self.getCurrentState().answer !== undefined) {
+      if (self.getCurrentState().answer !== undefined) {
         currentResponse += answerGroup.isCorrect() ? getCorrectAnswer() : getWrongAnswer();
       }
       xAPIEvent.data.statement.result.response = currentResponse;
     };
-   }
+  }
 
   // Inheritance
   TrueFalse.prototype = Object.create(Question.prototype);

--- a/scripts/h5p-true-false.js
+++ b/scripts/h5p-true-false.js
@@ -273,6 +273,8 @@ H5P.TrueFalse = (function ($, Question) {
       var score = self.getScore();
       var scoreText;
 
+      answerGroup.setAnswer(null);
+
       toggleButtonState(score === MAX_SCORE ? State.FINISHED_CORRECT : State.FINISHED_WRONG);
 
       if (score === MAX_SCORE && params.behaviour.feedbackOnCorrect) {


### PR DESCRIPTION
The function getAnswerGiven should report true if an answer has been given.
Other content types return true if either an answer has been given explicitly
or nothing has been answered explicity, but "check" has been clicked.

True-False did not do the latter. In Course Presentation, this led to inconsistent behavior in the navigation bar. Other content types would report _true_ when clicking on the check button even without giving an answer and the dot on the slide's navigation bar would be filled. It would not be filled for TrueFalse however if no answer was chosen before clicking on the check button.