### PR TITLE
Patch h5p-true-false-answer custom radio keydown event

### DIFF
--- a/scripts/h5p-true-false-answer.js
+++ b/scripts/h5p-true-false-answer.js
@@ -44,9 +44,11 @@ H5P.TrueFalse.Answer = (function ($, EventDispatcher) {
           return;
         }
         if ([Keys.SPACE, Keys.ENTER].indexOf(event.keyCode) !== -1) {
+          event.preventDefault();
           self.check();
         }
         else if ([Keys.LEFT_ARROW, Keys.UP_ARROW, Keys.RIGHT_ARROW, Keys.DOWN_ARROW].indexOf(event.keyCode) !== -1) {
+          event.preventDefault();
           self.uncheck();
           self.trigger('invert');
         }


### PR DESCRIPTION
Prevent default behaviour first for arrow and space keys.

This is required when implementing custom made interactive elements (a radio in this case)

See https://www.w3.org/TR/wai-aria-practices-1.1/#read_me_first for further reading.