### PR TITLE
Revert "HFP-3687 fix screen readers scoreBar double read"

### DIFF
--- a/scripts/h5p-true-false.js
+++ b/scripts/h5p-true-false.js
@@ -283,7 +283,6 @@ H5P.TrueFalse = (function ($, Question) {
       // Create feedback widget
       var score = self.getScore();
       var scoreText;
-      var scoreBarLabel = params.l10n.scoreBarLabel;
 
       toggleButtonState(score === MAX_SCORE ? State.FINISHED_CORRECT : State.FINISHED_WRONG);
 
@@ -295,11 +294,10 @@ H5P.TrueFalse = (function ($, Question) {
       }
       else {
         scoreText = params.l10n.score;
-        scoreBarLabel = ''; // HFP-3687: avoid screen readers reading seemingly duplicate labels
       }
       // Replace relevant variables:
       scoreText = scoreText.replace('@score', score).replace('@total', MAX_SCORE);
-      self.setFeedback(scoreText, score, MAX_SCORE, scoreBarLabel);
+      self.setFeedback(scoreText, score, MAX_SCORE, params.l10n.scoreBarLabel);
       answerGroup.reveal();
     };
 


### PR DESCRIPTION
The fix this commit was linked with focused a hidden aria-live element. Setting focus to a hidden element causes problems in several other content types (amongst other things breaking keyboard navigation completely in Sort the Paragraphs). We'll revert it for now, and look for a better solution later.